### PR TITLE
add side-door zone for RFID authentication

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,7 @@ CHECKR_PACKAGE = os.getenv("CHECKR_PACKAGE")
 # No longer checking the "COVID training" checkbox
 ZONE_REQUIREMENTS = {
     "front-door": frozenset(),
+    "side-door": frozenset(),
 }
 
 # END CONFIGURABLE OPTIONS


### PR DESCRIPTION
Looks like we're checking for permissions for a given zone. Needed to add a "side-door" zone.