### PR TITLE
Add support for multiple fob fields, and CSV fob fields

### DIFF
--- a/main.py
+++ b/main.py
@@ -106,7 +106,7 @@ class User(NamedTuple):
     account_id: str
     name: str
     email: Optional[str]
-    fobs: Optional[List[str]]
+    fobs: List[str]
     zones: frozenset[str]
     is_membership_expired: bool
     added_to_dm_members: bool


### PR DESCRIPTION
In order to support RFID access control for machines in the space via https://github.com/jantman/machine-access-control we've added another field to Neon, `FobCSV`, which accepts an arbitrary length CSV string of fob codes; the extra field was added to allow testing and rolling out the machine RFID system without impacting access to the space. This PR adds support for a list of field names to get fob numbers from, and also parses each of those fields so that it can include a CSV list of multiple fobs.

Obviously I won't merge this until I'm at the space and have ample time to test and roll back if needed. 